### PR TITLE
Create interfaces for proc_container and proc_preparable

### DIFF
--- a/apm.go
+++ b/apm.go
@@ -50,16 +50,16 @@ var (
 	serveConfigFile = serve.Flag("config-file", "Config file location").String()
 
 	resurrect     = app.Command("resurrect", "Resurrect all previously save processes.")
-	
+
 	bin           = app.Command("bin", "Create bin process.")
 	binSourcePath = bin.Flag("source", "Go project source path. (Ex: github.com/topfreegames/apm)").Required().String()
 	binName       = bin.Arg("name", "Process name.").Required().String()
 	binKeepAlive  = bin.Flag("keep-alive", "Keep process alive forever.").Required().Bool()
 	binArgs       = bin.Flag("args", "External args.").Strings()
-	
+
 	restart     = app.Command("restart", "Restart a process.")
 	restartName = restart.Arg("name", "Process name.").Required().String()
-	
+
 	start     = app.Command("start", "Start a process.")
 	startName = start.Arg("name", "Process name.").Required().String()
 
@@ -70,7 +70,7 @@ var (
 	deleteName = delete.Arg("name", "Process name.").Required().String()
 
 	save = app.Command("save", "Save a list of processes onto a file.")
-	
+
 	status = app.Command("status", "Get APM status.")
 )
 

--- a/lib/cli/cli.go
+++ b/lib/cli/cli.go
@@ -86,13 +86,13 @@ func (cli *Cli) DeleteProcess(procName string) {
 
 // Status will display the status of all procs started through StartGoBin.
 func (cli *Cli) Status() {
-	procs, err := cli.remoteClient.MonitStatus()
+	procResponse, err := cli.remoteClient.MonitStatus()
 	if err != nil {
 		log.Fatalf("Failed to get status due to: %+v\n", err)
 	}
 	maxName := 0
-	for id := range procs {
-		proc := procs[id]
+	for id := range procResponse.Procs {
+		proc := procResponse.Procs[id]
 		maxName = int(math.Max(float64(maxName), float64(len(proc.Name))))
 	}
 	totalSize := maxName + 51;
@@ -107,8 +107,8 @@ func (cli *Cli) Status() {
 		PadString("keep-alive", 15))
 	fmt.Println(topBar)
 	fmt.Println(infoBar)
-	for id := range procs {
-		proc := procs[id]
+	for id := range procResponse.Procs {
+		proc := procResponse.Procs[id]
 		kp := "True"
 		if !proc.KeepAlive {
 			kp = "False"

--- a/lib/master/master.go
+++ b/lib/master/master.go
@@ -47,6 +47,9 @@ type Master struct {
 	Procs map[string]process.ProcContainer // Procs is a map containing all procs started on APM.
 }
 
+// DecodableMaster is a struct that the config toml file will decode to.
+// It is needed because toml decoder doesn't decode to interfaces, so the
+// Procs map can't be decoded as long as we use the ProcContainer interface
 type DecodableMaster struct {
 	SysFolder string
 	PidFile string

--- a/lib/preparable/process.go
+++ b/lib/preparable/process.go
@@ -5,9 +5,19 @@ import "strings"
 
 import "github.com/topfreegames/apm/lib/process"
 
+type ProcPreparable interface {
+	PrepareBin() ([]byte, error)
+	Start() (process.ProcContainer, error)
+	getPath() string
+	Identifier() string
+	getBinPath() string
+	getPidPath() string
+	getOutPath() string
+	getErrPath() string
+}
 // ProcPreparable is a preparable with all the necessary informations to run
 // a process. To actually run a process, call the Start() method.
-type ProcPreparable struct {
+type Preparable struct {
 	Name       string
 	SourcePath string
 	Cmd        string
@@ -20,20 +30,20 @@ type ProcPreparable struct {
 // PrepareBin will compile the Golang project from SourcePath and populate Cmd with the proper
 // command for the process to be executed.
 // Returns the compile command output.
-func (proc_preparable *ProcPreparable) PrepareBin() ([]byte, error) {
+func (preparable *Preparable) PrepareBin() ([]byte, error) {
 	// Remove the last character '/' if present
-	if proc_preparable.SourcePath[len(proc_preparable.SourcePath)-1] == '/' {
-		proc_preparable.SourcePath = strings.TrimSuffix(proc_preparable.SourcePath, "/")
+	if preparable.SourcePath[len(preparable.SourcePath)-1] == '/' {
+		preparable.SourcePath = strings.TrimSuffix(preparable.SourcePath, "/")
 	}
 	cmd := ""
 	cmdArgs := []string{}
-	binPath := proc_preparable.getBinPath()
-	if proc_preparable.Language == "go" {
+	binPath := preparable.getBinPath()
+	if preparable.Language == "go" {
 		cmd = "go"
-		cmdArgs = []string{"build", "-o", binPath, proc_preparable.SourcePath + "/."}
+		cmdArgs = []string{"build", "-o", binPath, preparable.SourcePath + "/."}
 	}
 
-	proc_preparable.Cmd = proc_preparable.getBinPath()
+	preparable.Cmd = preparable.getBinPath()
 	return exec.Command(cmd, cmdArgs...).Output()
 }
 
@@ -41,16 +51,16 @@ func (proc_preparable *ProcPreparable) PrepareBin() ([]byte, error) {
 // This function should be called from inside the master to make sure
 // all the watchers and process handling are done correctly.
 // Returns a tuple with the process and an error in case there's any.
-func (proc_preparable *ProcPreparable) Start() (*process.Proc, error) {
+func (preparable *Preparable) Start() (process.ProcContainer, error) {
 	proc := &process.Proc{
-		Name:      proc_preparable.Name,
-		Cmd:       proc_preparable.Cmd,
-		Args:      proc_preparable.Args,
-		Path:      proc_preparable.getPath(),
-		Pidfile:   proc_preparable.getPidPath(),
-		Outfile:   proc_preparable.getOutPath(),
-		Errfile:   proc_preparable.getErrPath(),
-		KeepAlive: proc_preparable.KeepAlive,
+		Name:      preparable.Name,
+		Cmd:       preparable.Cmd,
+		Args:      preparable.Args,
+		Path:      preparable.getPath(),
+		Pidfile:   preparable.getPidPath(),
+		Outfile:   preparable.getOutPath(),
+		Errfile:   preparable.getErrPath(),
+		KeepAlive: preparable.KeepAlive,
 		Status:    &process.ProcStatus{},
 	}
 
@@ -58,25 +68,29 @@ func (proc_preparable *ProcPreparable) Start() (*process.Proc, error) {
 	return proc, err
 }
 
-func (proc_preparable *ProcPreparable) getPath() string {
-	if proc_preparable.SysFolder[len(proc_preparable.SysFolder)-1] == '/' {
-		proc_preparable.SysFolder = strings.TrimSuffix(proc_preparable.SysFolder, "/")
+func (preparable *Preparable) Identifier() string {
+	return preparable.Name;
+}
+
+func (preparable *Preparable) getPath() string {
+	if preparable.SysFolder[len(preparable.SysFolder)-1] == '/' {
+		preparable.SysFolder = strings.TrimSuffix(preparable.SysFolder, "/")
 	}
-	return proc_preparable.SysFolder + "/" + proc_preparable.Name
+	return preparable.SysFolder + "/" + preparable.Name
 }
 
-func (proc_preparable *ProcPreparable) getBinPath() string {
-	return proc_preparable.getPath() + "/" + proc_preparable.Name
+func (preparable *Preparable) getBinPath() string {
+	return preparable.getPath() + "/" + preparable.Name
 }
 
-func (proc_preparable *ProcPreparable) getPidPath() string {
-	return proc_preparable.getBinPath() + ".pid"
+func (preparable *Preparable) getPidPath() string {
+	return preparable.getBinPath() + ".pid"
 }
 
-func (proc_preparable *ProcPreparable) getOutPath() string {
-	return proc_preparable.getBinPath() + ".out"
+func (preparable *Preparable) getOutPath() string {
+	return preparable.getBinPath() + ".out"
 }
 
-func (proc_preparable *ProcPreparable) getErrPath() string {
-	return proc_preparable.getBinPath() + ".err"
+func (preparable *Preparable) getErrPath() string {
+	return preparable.getBinPath() + ".err"
 }


### PR DESCRIPTION
The main goal here is to add tests to the APM. When implementing tests, I noticed that Golang is not mocking friendly, which makes it hard to implement tests the way APM is structured right now.

The first step to make it test-friendly is to make APM more interface oriented. This means we should create interface for our main modules and work with them. By doing this we gain the ability to easily mock the interface and create more robust tests the way we like.

The first tests I want to create are tests for the proc_container which controls the logic for each APM process. So this pull request basically creates an interface for it and for proc_preparable as well.

The only problem when making APM more interface oriented is that it makes encoding/decoding structs more hard. For instance, when we make calls from the remote client to the remote server, the RPC module will encode and then decode the object we want to send through. The problem with that is that interfaces can't be decoded, since there's no way to access its fields as interfaces in golang only exposes modules and not exported fields. We have this exactly same problem when encoding/decoding the master from/to the TOML file.

The first solution that I had in mind was:
- Create a struct with the exactly same fields as the struct we want to encode/decode, and then use it to receive and send data. After we receive this data, we just copy and paste it onto the actual object we are gonna handle. This solution can be seen by looking at the structs: DecodableMaster and ProcDataResponse.

- The problem with this solution is that we will always have to keep the auxiliar structs sync with the actual structs. This won't scale when we have more fields, but it solves the problem for now.


Besides that, this change was manually tested against all possible cases, and it seems to be working just fine.
